### PR TITLE
Explicitly pass deep argument

### DIFF
--- a/src/strategies/container.js
+++ b/src/strategies/container.js
@@ -59,7 +59,7 @@
      * @param {HTMLElement} element
      */
     ImagerContainerStrategy.prototype.createPlaceholder = function createPlaceholder (element) {
-        var placeholder = this.element.cloneNode();
+        var placeholder = this.element.cloneNode(false);
 
         if (element.hasAttribute('data-width')) {
             placeholder.width = element.getAttribute('data-width');


### PR DESCRIPTION
Firefox < 13 blows up without it

New spec says it defaults to `false`, so explicitly setting to false

See https://developer.mozilla.org/en-US/docs/Web/API/Node.cloneNode
